### PR TITLE
handle XML escape character in graphml encoder

### DIFF
--- a/netconv/encoders.py
+++ b/netconv/encoders.py
@@ -72,6 +72,7 @@ def encode_graphml(graph):
     text += '</graph>\n'
     text += '</graphml>\n'
 
+    text = text.replace('&', '&amp;')
     return text
 
 


### PR DESCRIPTION
This came up when trying to decode and then encode the imdb dataset. Because the ampersand is an escape character in XML, printing the ampersand directly produces an XML file that cannot be parsed by LXML.